### PR TITLE
Patch remove tags

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -337,7 +337,7 @@ function Qless.tag(now, command, ...)
       local _tags = {}
       for i,v in ipairs(tags) do _tags[v] = true end
 
-      -- Otherwise, add the job to the sorted set with that tags
+      -- Otherwise, remove the job from the sorted set with that tags
       for i=2,#arg do
         local tag = arg[i]
         _tags[tag] = nil

--- a/job.lua
+++ b/job.lua
@@ -390,7 +390,7 @@ function QlessJob:fail(now, worker, group, message, data)
   -- And add this particular instance to the failed groups
   redis.call('lpush', 'ql:f:' .. group, self.jid)
 
-  -- Here is where we'd intcrement stats about the particular stage
+  -- Here is where we'd increment stats about the particular stage
   -- and possibly the workers
 
   return self.jid
@@ -862,16 +862,23 @@ end
 -- this should probably be moved to its own tag
 -- object.
 function QlessJob:remove_tag(tag)
+  -- namespace the tag
+  local namespaced_tag = 'ql:t:' .. tag
+
   -- Remove the job from the specified tag
-  redis.call('zrem', 'ql:t:' .. tag, self.jid)
+  redis.call('zrem', namespaced_tag, self.jid)
 
-  -- Decrement the tag in the set of all tags.
-  local score = redis.call('zincrby', 'ql:tags', -1, tag)
+  -- Check if any tags jids remain in the tag set.
+  local remaining = redis.call('zcard', namespaced_tag)
 
-  -- if the score for the specified tag is 0
-  -- it means we have no jobs with this tag anymore
-  -- and we should remove it from the set to prevent memory leaks.
-  if tonumber(score) == 0 then
+  -- If the number of jids in the tagged set
+  -- is 0 it means we have no jobs with this tag
+  -- and we should remove it from the set of all tags
+  -- to prevent memory leaks.
+  if tonumber(remaining) == 0 then
     redis.call('zrem', 'ql:tags', tag)
+  else
+    -- Decrement the tag in the set of all tags.
+    redis.call('zincrby', 'ql:tags', -1, tag)
   end
 end


### PR DESCRIPTION
Basically using the score isn't reliable apparently there is a way to end up with a negative score. (I am unsure of the exact conditions this occurs under, I believe it has something to do with the cancelling path)
Instead lets use the actual size of the tag set to determine if we should remove from the global tags set.

also fixed some comments.
